### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,6 @@ To enable this feature, change the constant `ADJUST_ORIENTATION` to `true`.
 
 More information, and an in depth analysis of EXIF Orientation can be found [in this article](http://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/) written by @[daveperrett](http://www.twitter.com/daveperrett)
 
-##License
+## License
 
 Thumb.php is licensed under the [MIT license](http://opensource.org/licenses/MIT), see [LICENSE.md](https://github.com/jamiebicknell/Thumb/blob/master/LICENSE.md) for details.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
